### PR TITLE
fix: color of objects and constructors

### DIFF
--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -6,13 +6,24 @@
     .syntax--support {
         &.syntax--variable {
             &.syntax--property {
-                color: @strong-orange;
+                color: @very-light-gray;
+            }
+        }
+    }
+
+    .syntax--entity {
+        &.syntax--name {
+            &.syntax--type {
+                color: @orange;
             }
         }
     }
 
     .syntax--variable {
         &.syntax--property {
+            color: @blue;
+        }
+        &.syntax--other.syntax--object {
             color: @very-light-gray;
         }
     }


### PR DESCRIPTION
color of object and object property; color of constructor calling with new - in cases like new TypeError(message)

**before**
![2017-01-18-17 52 26_1280x1024_scrot](https://cloud.githubusercontent.com/assets/5038030/22071014/8993aa58-dda6-11e6-86cb-c95efdce2cc4.png)

**after** (notice L63, L83 and L94-95)
![2017-01-18-17 51 32_1280x1024_scrot](https://cloud.githubusercontent.com/assets/5038030/22071001/7cd6df92-dda6-11e6-875e-251952a5d32c.png)

**sublime**
![2017-01-18-17 52 50_1280x1024_scrot](https://cloud.githubusercontent.com/assets/5038030/22071037/97a9b704-dda6-11e6-9187-b98f9921221d.png)
