### PR TITLE
fix: js lang: parens/brackets and the default keyword

### DIFF
--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -8,6 +8,9 @@
             &.syntax--property {
                 color: @very-light-gray;
             }
+            &.syntax--property.syntax--dom {
+                color: @blue;
+            }
         }
     }
 
@@ -36,5 +39,16 @@
         &.syntax--boolean {
             color: @red;
         }
+    }
+
+    .syntax--punctuation.syntax--begin,
+    .syntax--punctuation.syntax--end,
+    .syntax--delimiter.syntax--object.syntax--comma,
+    .syntax--brace.syntax--curly {
+        color: @cyan;
+    }
+
+    .syntax--export .syntax--variable.syntax--default {
+        color: @purple;
     }
 }

--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -29,6 +29,15 @@
         &.syntax--other.syntax--object {
             color: @very-light-gray;
         }
+        &.syntax--other.syntax--object.syntax--property {
+            color: @blue;
+        }
+    }
+
+    .syntax--string.syntax--quoted.syntax--template {
+      .syntax--other.syntax--object.syntax--property {
+          color: @green;
+      }
     }
 
     .syntax--constant {


### PR DESCRIPTION
- `default` keyword was red
- some brackets, curly braces and commas was white (which are not "operator"), should be `cyan`
- didn't recognize objects

(damn, will update the pics in a sec)

example for last bullet

**sublime** (notice brackets, commas and `result.code`)

![2017-01-22-02 09 23_1280x1024_scrot](https://cloud.githubusercontent.com/assets/5038030/22178710/81aa1982-e047-11e6-859f-b6ca52144f30.png)
![2017-01-22-02 09 20_1280x1024_scrot](https://cloud.githubusercontent.com/assets/5038030/22178709/81a8f174-e047-11e6-91ed-80f26d7aae5f.png)


**before**
![2017-01-22-02 11 53_1280x1024_scrot](https://cloud.githubusercontent.com/assets/5038030/22178722/d9566668-e047-11e6-9c7d-58d0e72faf00.png)
![2017-01-22-02 11 48_1280x1024_scrot](https://cloud.githubusercontent.com/assets/5038030/22178723/d9566a50-e047-11e6-9091-9c06a8311ddd.png)

**after**
![2017-01-22-02 12 24_1280x1024_scrot](https://cloud.githubusercontent.com/assets/5038030/22178725/e7aecc5a-e047-11e6-9d29-a4f4494f5432.png)
![2017-01-22-02 12 22_1280x1024_scrot](https://cloud.githubusercontent.com/assets/5038030/22178726/e7b42326-e047-11e6-8a2a-d8f4350dd05d.png)
