### PR TITLE
Make support types orange again

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -233,9 +233,7 @@ atom-text-editor .search-results .syntax--marker.current-result .region {
     }
 
     &.syntax--type {
-        &.syntax--property-name {
-            color: @light-gray;
-        }
+        color: @orange;
     }
 
     &.syntax--variable {


### PR DESCRIPTION
Without my change:
![](https://i.m4gnus.de/files/ufaej4.png)

With my change:
![](https://i.m4gnus.de/files/jcd6ep.png)

white (and gray) types are hard to see next to white identifiers. plz merge, kthxbye