### PR TITLE
Make cusor line transparent so brackets can be highlighted

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -17,7 +17,7 @@ atom-text-editor {
     }
 
     .cursor-line {
-        background-color: darken(@syntax-background-color, 2.5%);
+        background-color: fade(darken(@syntax-background-color, 20%), 20%);
     }
 
     .gutter {


### PR DESCRIPTION
This should fix #82 by making the cusor line transparent so matching bracket highlights show through. This seems to be the standard behaviour for other themes.